### PR TITLE
Add modified MuJoCo envs better adapted to IRL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,7 @@ inputs =
 	tests/
 	setup.py
 python_version = 3.7
+
+[tool:pytest]
+markers =
+    expensive: mark a test as expensive (deselect with '-m "not expensive"')

--- a/src/benchmark_environments/__init__.py
+++ b/src/benchmark_environments/__init__.py
@@ -4,8 +4,9 @@ from gym.envs.registration import register
 
 __version__ = "0.01"
 
-register(
-    id='benchmark_environments/HalfCheetah-v0',
-    entry_point='benchmark_environments.mujoco:HalfCheetahEnv',
-    max_episode_steps=200
-)
+for env_base in ['HalfCheetah', 'Ant', 'Hopper', 'Humanoid', 'Swimmer', 'Walker2d']:
+    register(
+        id=f'benchmark_environments/{env_base}-v0',
+        entry_point=f'benchmark_environments.mujoco:{env_base}Env',
+        max_episode_steps=200
+    )

--- a/src/benchmark_environments/__init__.py
+++ b/src/benchmark_environments/__init__.py
@@ -1,8 +1,11 @@
+"""Benchmark environments for reward modeling and imitation."""
+
 from gym.envs.registration import register
 
 __version__ = "0.01"
 
 register(
-    id='FixedHalfCheetah-v0',
-    entry_point='benchmark_environments.mujoco:HalfCheetahEnv'
+    id='benchmark_environments/HalfCheetah-v0',
+    entry_point='benchmark_environments.mujoco:HalfCheetahEnv',
+    max_episode_steps=200
 )

--- a/src/benchmark_environments/__init__.py
+++ b/src/benchmark_environments/__init__.py
@@ -1,1 +1,8 @@
+from gym.envs.registration import register
+
 __version__ = "0.01"
+
+register(
+    id='FixedHalfCheetah-v0',
+    entry_point='benchmark_environments.mujoco:HalfCheetahEnv'
+)

--- a/src/benchmark_environments/__init__.py
+++ b/src/benchmark_environments/__init__.py
@@ -1,12 +1,15 @@
 """Benchmark environments for reward modeling and imitation."""
 
-from gym.envs.registration import register
+import gym
 
 __version__ = "0.01"
 
+def get_gym_v3_max_episode_steps(env_base):
+    return gym.envs.registry.env_specs[f'{env_base}-v3'].max_episode_steps
+
 for env_base in ['HalfCheetah', 'Ant', 'Hopper', 'Humanoid', 'Swimmer', 'Walker2d']:
-    register(
+    gym.register(
         id=f'benchmark_environments/{env_base}-v0',
         entry_point=f'benchmark_environments.mujoco:{env_base}Env',
-        max_episode_steps=200
+        max_episode_steps=get_gym_v3_max_episode_steps(env_base)
     )

--- a/src/benchmark_environments/mujoco.py
+++ b/src/benchmark_environments/mujoco.py
@@ -2,21 +2,48 @@
 """
 
 import gym
-from gym.envs.mujoco import half_cheetah_v3
+from gym.envs.mujoco import half_cheetah_v3, ant_v3, hopper_v3, humanoid_v3, swimmer_v3, walker2d_v3
 
-class HalfCheetahEnv(half_cheetah_v3.HalfCheetahEnv):
-    """HalfCheetah with center of mass in observation.
-    """
-    def __init__(self, *args, **kwargs):
-        """
-        Args:
-            xml_file (str): Asset file describing the half cheetah model.
-                Default: 'half_cheetah.xml'
-            forward_reward_weight (float): weight in reward for moving forward.
-                Default: 1.0
-            ctrl_cost_weight (float): weight in reward for action cost. Default: 0.1
-            reset_noise_scale (float): Standard deviation of sample for initial
-                position/velocity. Default: 0.1
-        """
+def include_position_in_observation(cls):
+    old_init = cls.__init__
+
+    def new_init(*args, **kwargs):
         kwargs['exclude_current_positions_from_observation'] = False
-        super().__init__(*args, **kwargs)
+        old_init(*args, **kwargs)
+
+    cls.__init__ = new_init
+    return cls
+
+def no_early_termination(cls):
+    cls.done = False
+    return cls
+
+@include_position_in_observation
+@no_early_termination
+class HalfCheetahEnv(half_cheetah_v3.HalfCheetahEnv):
+    pass
+
+@include_position_in_observation
+@no_early_termination
+class AntEnv(ant_v3.AntEnv):
+    pass
+
+@include_position_in_observation
+@no_early_termination
+class HopperEnv(hopper_v3.HopperEnv):
+    pass
+
+@include_position_in_observation
+@no_early_termination
+class HumanoidEnv(humanoid_v3.HumanoidEnv):
+    pass
+
+@include_position_in_observation
+@no_early_termination
+class SwimmerEnv(swimmer_v3.SwimmerEnv):
+    pass
+
+@include_position_in_observation
+@no_early_termination
+class Walker2dEnv(walker2d_v3.Walker2dEnv):
+    pass

--- a/src/benchmark_environments/mujoco.py
+++ b/src/benchmark_environments/mujoco.py
@@ -1,22 +1,22 @@
+"""Adaptation of MuJoCo environments for IRL.
+"""
+
 import gym
 from gym.envs.mujoco import half_cheetah_v3
 
 class HalfCheetahEnv(half_cheetah_v3.HalfCheetahEnv):
-    def __init__(self, *args, time_horizon=200, **kwargs):
-        self._time_horizon = time_horizon
-        self._step_count = 0
+    """HalfCheetah with center of mass in observation.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Args:
+            xml_file (str): Asset file describing the half cheetah model.
+                Default: 'half_cheetah.xml'
+            forward_reward_weight (float): weight in reward for moving forward.
+                Default: 1.0
+            ctrl_cost_weight (float): weight in reward for action cost. Default: 0.1
+            reset_noise_scale (float): Standard deviation of sample for initial
+                position/velocity. Default: 0.1
+        """
         kwargs['exclude_current_positions_from_observation'] = False
         super().__init__(*args, **kwargs)
-
-    @property
-    def done(self):
-        return self._step_count >= self._time_horizon
-
-    def step(self, action):
-        self._step_count += 1
-        ob, re, _, info = super().step(action)
-        return ob, re, self.done, info
-
-    def reset(self):
-        self._step_count = 0
-        return super().reset()

--- a/src/benchmark_environments/mujoco.py
+++ b/src/benchmark_environments/mujoco.py
@@ -1,0 +1,22 @@
+import gym
+from gym.envs.mujoco import half_cheetah_v3
+
+class HalfCheetahEnv(half_cheetah_v3.HalfCheetahEnv):
+    def __init__(self, *args, time_horizon=200, **kwargs):
+        self._time_horizon = time_horizon
+        self._step_count = 0
+        kwargs['exclude_current_positions_from_observation'] = False
+        super().__init__(*args, **kwargs)
+
+    @property
+    def done(self):
+        return self._step_count >= self._time_horizon
+
+    def step(self, action):
+        self._step_count += 1
+        ob, re, _, info = super().step(action)
+        return ob, re, self.done, info
+
+    def reset(self):
+        self._step_count = 0
+        return super().reset()

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-@pytest.mark.parametrize("i", range(20))
-def test_dummy(i):
-    # TODO(adam): remove me once we have real tests!
-    assert True

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,10 @@
+"""Dummy file to make CI not complain. Delete once we have real tests!"""
+
+import pytest
+
+
+@pytest.mark.parametrize("i", range(20))
+def test_dummy(i):
+    """Dummy test to make CI not complain."""
+    # TODO(adam): remove me once we have real tests!
+    assert True

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -1,3 +1,5 @@
+"""Test MuJoCo adaptations."""
+
 from stable_baselines.common.policies import MlpPolicy
 from stable_baselines.common.vec_env import DummyVecEnv
 from stable_baselines import PPO2
@@ -11,7 +13,7 @@ def test_fixed_env_model_as_good_as_gym_env_model():
     verbose = 0
 
     gym_env = gym.make('HalfCheetah-v3')
-    fixed_env = gym.make('FixedHalfCheetah-v0')
+    fixed_env = gym.make('benchmark_environments/HalfCheetah-v0')
 
     gym_model = PPO2(MlpPolicy, gym_env, verbose=verbose)
     gym_model.learn(total_timesteps=train_timesteps)
@@ -19,10 +21,12 @@ def test_fixed_env_model_as_good_as_gym_env_model():
     fixed_model = PPO2(MlpPolicy, fixed_env, verbose=verbose)
     fixed_model.learn(total_timesteps=train_timesteps)
 
+    max_timesteps_per_episode = fixed_env.spec.max_episode_steps
+
     gym_reward = _eval_model(gym_model, gym_env, num_episodes=num_eval_episodes,
-            max_timesteps_per_episode=fixed_env._time_horizon)
+            max_timesteps_per_episode=max_timesteps_per_episode)
     fixed_reward = _eval_model(fixed_model, fixed_env, num_episodes=num_eval_episodes,
-            max_timesteps_per_episode=fixed_env._time_horizon)
+            max_timesteps_per_episode=max_timesteps_per_episode)
 
     epsilon = 0.1
     sign = 1 if gym_reward > 0 else -1

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -1,0 +1,47 @@
+from stable_baselines.common.policies import MlpPolicy
+from stable_baselines.common.vec_env import DummyVecEnv
+from stable_baselines import PPO2
+
+import gym
+import benchmark_environments
+
+def test_fixed_env_model_as_good_as_gym_env_model():
+    train_timesteps = 200000
+    num_eval_episodes = 50
+    verbose = 0
+
+    gym_env = gym.make('HalfCheetah-v3')
+    fixed_env = gym.make('FixedHalfCheetah-v0')
+
+    gym_model = PPO2(MlpPolicy, gym_env, verbose=verbose)
+    gym_model.learn(total_timesteps=train_timesteps)
+
+    fixed_model = PPO2(MlpPolicy, fixed_env, verbose=verbose)
+    fixed_model.learn(total_timesteps=train_timesteps)
+
+    gym_reward = _eval_model(gym_model, gym_env, num_episodes=num_eval_episodes,
+            max_timesteps_per_episode=fixed_env._time_horizon)
+    fixed_reward = _eval_model(fixed_model, fixed_env, num_episodes=num_eval_episodes,
+            max_timesteps_per_episode=fixed_env._time_horizon)
+
+    epsilon = 0.1
+    sign = 1 if gym_reward > 0 else -1
+    assert (1 - sign * epsilon) * gym_reward <= fixed_reward
+
+def _eval_model(model, env, *, num_episodes, max_timesteps_per_episode):
+    total_re = 0
+
+    for episode in range(num_episodes):
+        ob = env.reset()
+        step = 0
+        done = False
+        while not done and step < max_timesteps_per_episode:
+            action, _ = model.predict(ob)
+            new_ob, re, done, _ = env.step(action)
+
+            total_re += re
+
+            ob = new_ob
+            step += 1
+
+    return total_re / num_episodes

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -8,25 +8,25 @@ from stable_baselines import PPO2
 import gym
 from gym.wrappers.time_limit import TimeLimit
 import benchmark_environments
+import pytest
 
-def test_fixed_env_model_as_good_as_gym_env_model():
+@pytest.mark.expensive
+@pytest.mark.parametrize("env_base",
+        ['HalfCheetah', 'Ant', 'Hopper', 'Humanoid', 'Swimmer', 'Walker2d'])
+def test_fixed_env_model_as_good_as_gym_env_model(env_base):
     train_timesteps = 200000
-    num_eval_episodes = 50
-    verbose = 0
 
-    gym_env = gym.make('HalfCheetah-v3')
-    fixed_env = gym.make('benchmark_environments/HalfCheetah-v0')
-
-    gym_model = PPO2(MlpPolicy, gym_env, verbose=verbose)
-    gym_model.learn(total_timesteps=train_timesteps)
-
-    fixed_model = PPO2(MlpPolicy, fixed_env, verbose=verbose)
-    fixed_model.learn(total_timesteps=train_timesteps)
-
-    gym_env_eval = TimeLimit(gym_env, fixed_env.spec.max_episode_steps)
-    gym_reward, _ = evaluate_policy(gym_model, gym_env_eval)
-    fixed_reward, _ = evaluate_policy(fixed_model, fixed_env)
+    gym_reward, _ = _eval_env(f'{env_base}-v3',
+                              total_timesteps=train_timesteps)
+    fixed_reward, _ = _eval_env(f'benchmark_environments/{env_base}-v0',
+                                total_timesteps=train_timesteps)
 
     epsilon = 0.1
     sign = 1 if gym_reward > 0 else -1
     assert (1 - sign * epsilon) * gym_reward <= fixed_reward
+
+def _eval_env(env_name, total_timesteps):
+    env = gym.make(env_name)
+    model = PPO2(MlpPolicy, env)
+    model.learn(total_timesteps=total_timesteps)
+    return evaluate_policy(model, env)

--- a/tests/test_mujoco.py
+++ b/tests/test_mujoco.py
@@ -1,10 +1,12 @@
 """Test MuJoCo adaptations."""
 
+from stable_baselines.common.evaluation import evaluate_policy
 from stable_baselines.common.policies import MlpPolicy
 from stable_baselines.common.vec_env import DummyVecEnv
 from stable_baselines import PPO2
 
 import gym
+from gym.wrappers.time_limit import TimeLimit
 import benchmark_environments
 
 def test_fixed_env_model_as_good_as_gym_env_model():
@@ -21,31 +23,10 @@ def test_fixed_env_model_as_good_as_gym_env_model():
     fixed_model = PPO2(MlpPolicy, fixed_env, verbose=verbose)
     fixed_model.learn(total_timesteps=train_timesteps)
 
-    max_timesteps_per_episode = fixed_env.spec.max_episode_steps
-
-    gym_reward = _eval_model(gym_model, gym_env, num_episodes=num_eval_episodes,
-            max_timesteps_per_episode=max_timesteps_per_episode)
-    fixed_reward = _eval_model(fixed_model, fixed_env, num_episodes=num_eval_episodes,
-            max_timesteps_per_episode=max_timesteps_per_episode)
+    gym_env_eval = TimeLimit(gym_env, fixed_env.spec.max_episode_steps)
+    gym_reward, _ = evaluate_policy(gym_model, gym_env_eval)
+    fixed_reward, _ = evaluate_policy(fixed_model, fixed_env)
 
     epsilon = 0.1
     sign = 1 if gym_reward > 0 else -1
     assert (1 - sign * epsilon) * gym_reward <= fixed_reward
-
-def _eval_model(model, env, *, num_episodes, max_timesteps_per_episode):
-    total_re = 0
-
-    for episode in range(num_episodes):
-        ob = env.reset()
-        step = 0
-        done = False
-        while not done and step < max_timesteps_per_episode:
-            action, _ = model.predict(ob)
-            new_ob, re, done, _ = env.step(action)
-
-            total_re += re
-
-            ob = new_ob
-            step += 1
-
-    return total_re / num_episodes


### PR DESCRIPTION
This adds a modified HalfCheetah environment with:
- observation with center of mass position: this is because the reward depends on the center of mass position, and having the information relevant to the reward in the observation simplifies the problem for IRL algorithms;
- no termination conditions and fixed time horizon, since termination conditions can be problematic by default to IRL algorithms (https://arxiv.org/abs/1809.02925)

---

I added a test comparing the original and the modified environment to catch differences in performance, but I'm not sure that is the best way of testing this; in any case, the modified environment model seems to learn much faster.

I'm also unsure of the best values for hyperparameters here.