### PR TITLE
Check for trailing commas where appropriate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ TESTS_REQUIRE = [
     "flake8",
     "flake8-blind-except",
     "flake8-builtins",
+    "flake8-commas",
     "flake8-debugger",
     "flake8-docstrings",
     "flake8-isort",

--- a/src/benchmark_environments/testing/envs.py
+++ b/src/benchmark_environments/testing/envs.py
@@ -15,7 +15,7 @@ Rollout = Sequence[Tuple[Any, Optional[float], bool, Mapping[str, Any]]]
 
 
 def make_env_fixture(
-    skip_fn: Callable[[str], None]
+    skip_fn: Callable[[str], None],
 ) -> Callable[[str], Iterator[gym.Env]]:
     """Creates a fixture function, calling `skip_fn` when dependencies are missing.
 

--- a/tests/test_mujoco_rl.py
+++ b/tests/test_mujoco_rl.py
@@ -12,7 +12,7 @@ import benchmark_environments.mujoco  # noqa: F401 Import required for env regis
 
 
 def _eval_env(
-    env_name: str, total_timesteps: int
+    env_name: str, total_timesteps: int,
 ) -> Tuple[float, int]:  # pragma: no cover
     """Train PPO2 for `total_timesteps` on `env_name` and evaluate returns."""
     env = gym.make(env_name)
@@ -23,7 +23,7 @@ def _eval_env(
 
 @pytest.mark.expensive
 @pytest.mark.parametrize(
-    "env_base", ["HalfCheetah", "Ant", "Hopper", "Humanoid", "Swimmer", "Walker2d"]
+    "env_base", ["HalfCheetah", "Ant", "Hopper", "Humanoid", "Swimmer", "Walker2d"],
 )
 def test_fixed_env_model_as_good_as_gym_env_model(env_base: str):  # pragma: no cover
     """Compare original and modified MuJoCo v3 envs."""
@@ -31,7 +31,7 @@ def test_fixed_env_model_as_good_as_gym_env_model(env_base: str):  # pragma: no 
 
     gym_reward, _ = _eval_env(f"{env_base}-v3", total_timesteps=train_timesteps)
     fixed_reward, _ = _eval_env(
-        f"benchmark_environments/{env_base}-v0", total_timesteps=train_timesteps
+        f"benchmark_environments/{env_base}-v0", total_timesteps=train_timesteps,
     )
 
     epsilon = 0.1


### PR DESCRIPTION
`black` adds trailing commas in some places by default when reformatting to break across lines, but does not add them if they're not already present in a multi-line environment. Lint for these to ensure consistency.

(This doesn't really matter that much, but it's an easy fix.)