### PR TITLE
Bugfix: make CartPole observations match observation space

### DIFF
--- a/src/benchmark_environments/classic_control.py
+++ b/src/benchmark_environments/classic_control.py
@@ -2,8 +2,8 @@
 
 import warnings
 
+from gym import spaces
 import gym.envs.classic_control
-import gym.wrappers
 import numpy as np
 
 from benchmark_environments import util
@@ -19,6 +19,19 @@ class FixedHorizonCartPole(gym.envs.classic_control.CartPoleEnv):
     in `TimeLimit` with max steps 500.)
     """
 
+    def __init__(self):
+        """Builds FixedHorizonCartPole, modifying observation_space from Gym parent."""
+        super().__init__()
+
+        high = [
+            np.finfo(np.float32).max,  # x axis
+            np.finfo(np.float32).max,  # x velocity
+            np.pi,  # theta in radians
+            np.finfo(np.float32).max,  # theta velocity
+        ]
+        high = np.array(high)
+        self.observation_space = spaces.Box(-high, high, dtype=np.float32)
+
     def step(self, action):
         """Step function for FixedHorizonCartPole."""
         with warnings.catch_warnings():
@@ -31,6 +44,7 @@ class FixedHorizonCartPole(gym.envs.classic_control.CartPoleEnv):
 
         # Normalize theta to [-pi, pi] range.
         theta = (theta + np.pi) % (2 * np.pi) - np.pi
+        self.state[2] = theta
 
         state_ok = bool(
             abs(x) < self.x_threshold and abs(theta) < self.theta_threshold_radians,

--- a/src/benchmark_environments/testing/envs.py
+++ b/src/benchmark_environments/testing/envs.py
@@ -139,17 +139,12 @@ def test_rollout_schema(
 ) -> None:
     """Check custom environments have correct types on `step` and `reset`.
 
-    Note this may continue taking `step()` action after `done` is True. This is
-    an abuse of the Gym API but we would like environments to handle this case
-    gracefully in any case.
-
     Args:
         env: The environment to test.
         steps_after_done: The number of steps to take after `done` is True, the nominal
             episode termination. This is an abuse of the Gym API, but we would like the
             environments to handle this case gracefully.
-        max_steps: If we do not get `done` after this many timesteps, stop and raise an
-            error.
+        max_steps: Test fails if we do not get `done` after this many timesteps.
 
     Raises:
         AssertionError if test fails.

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -4,7 +4,6 @@ import gym
 import pytest
 
 import benchmark_environments  # noqa: F401 required for env registration
-from benchmark_environments import util
 from benchmark_environments.testing import envs
 
 ENV_NAMES = [
@@ -31,7 +30,6 @@ class TestEnvs:
         """Tests if step() before reset() raises error."""
         envs.test_premature_step(env, skip_fn=pytest.skip, raises_fn=pytest.raises)
 
-    def test_rollout_schema(self, env: gym.Env, env_name: str):
+    def test_rollout_schema(self, env: gym.Env):
         """Tests if environments have correct types on `step()` and `reset()`."""
-        max_episode = util.get_gym_max_episode_steps(env_name) or 100
-        envs.test_rollout_schema(env, num_steps=max_episode + 10)
+        envs.test_rollout_schema(env)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -4,6 +4,7 @@ import gym
 import pytest
 
 import benchmark_environments  # noqa: F401 required for env registration
+from benchmark_environments import util
 from benchmark_environments.testing import envs
 
 ENV_NAMES = [
@@ -22,14 +23,15 @@ env = pytest.fixture(envs.make_env_fixture(skip_fn=pytest.skip))
 class TestEnvs:
     """Battery of simple tests for environments."""
 
-    def test_seed(self, env, env_name):
+    def test_seed(self, env: gym.Env, env_name: str):
         """Tests environment seeding."""
         envs.test_seed(env, env_name, DETERMINISTIC_ENVS)
 
-    def test_premature_step(self, env):
+    def test_premature_step(self, env: gym.Env):
         """Tests if step() before reset() raises error."""
         envs.test_premature_step(env, skip_fn=pytest.skip, raises_fn=pytest.raises)
 
-    def test_rollout_schema(self, env):
+    def test_rollout_schema(self, env: gym.Env, env_name: str):
         """Tests if environments have correct types on `step()` and `reset()`."""
-        envs.test_rollout_schema(env)
+        max_episode = util.get_gym_max_episode_steps(env_name) or 100
+        envs.test_rollout_schema(env, num_steps=max_episode + 10)


### PR DESCRIPTION
This PR:
  - Extends `test_rollout_schema` to perform rollouts until episode terminates, and then for `steps_after_done` after this. This now catches a bug in `CartPole`: the observation space limits were set based on what would happen before `done` is `True`, but can exceed that now we've made it fixed horizon.
  - Fixes this bug in CartPole by extending observation space.
  - Additionally, changes CartPole to normalize `theta` in the returned state which I think was the intention? Otherwise the policy has to learn to be invariant to `mod 2\pi` translations which feels odd. This does have the downside of discontinuous transitions from +pi to -pi around that border but I think that's the lesser of the two evils.