### PR TITLE
Relax overly strict test check

### DIFF
--- a/src/benchmark_environments/testing/envs.py
+++ b/src/benchmark_environments/testing/envs.py
@@ -170,8 +170,7 @@ def test_rollout_schema(
     assert done is True, "did not get to end of episode"
 
     for _ in range(steps_after_done):
-        done = _sample_and_check()
-        assert done is True, "episode restarted without explicit reset"
+        _sample_and_check()
 
 
 def test_premature_step(env: gym.Env, skip_fn, raises_fn) -> None:


### PR DESCRIPTION
It's ok for environments to go from done to not done, since behaviour when calling `step()` after done is undefined. While it should still be *sane*, we don't environments to have to keep state as to whether they already terminated.